### PR TITLE
Fix SQL values' quoting, to fix module backup under PostgreSQL

### DIFF
--- a/backup/moodle2/backup_pdfannotator_stepslib.php
+++ b/backup/moodle2/backup_pdfannotator_stepslib.php
@@ -97,7 +97,7 @@ class backup_pdfannotator_activity_structure_step extends backup_activity_struct
             // Add all annotations specific to this annotator instance.
             $annotation->set_source_sql('SELECT a.* FROM {pdfannotator_annotations} a '
                                         . 'JOIN {pdfannotator_comments} c ON a.id = c.annotationid '
-                                        . 'WHERE a.pdfannotatorid = ? AND c.isquestion = "1" AND (c.visibility = "public" OR c.visibility = "anonymous") ',
+                                        . "WHERE a.pdfannotatorid = ? AND c.isquestion = 1 AND (c.visibility = 'public' OR c.visibility = 'anonymous') ",
                                         array('pdfannotatorid' => backup::VAR_PARENTID));
 
                 // Add any subscriptions to this annotation.


### PR DESCRIPTION
Module backup fails on a Moodle install on a PostgreSQL database, with the following error:
```
ERROR: column "1" does not exist
```

This is due to the use of double quotes around SQL _values_ in the SQL request. PostgreSQL requires the use of single-quotes, and these are supported by MySQL too.