### PR TITLE
Fix type errors in statistics on PHP 8

### DIFF
--- a/model/statistics.class.php
+++ b/model/statistics.class.php
@@ -85,7 +85,7 @@ class pdfannotator_statistics {
                 . "WHERE pdfannotatorid = ? AND isquestion = ? AND isdeleted = ? "
                 . "GROUP BY userid ) AS counts";
 
-        return key($DB->get_records_sql($sql, array($this->annotatorid, $isquestion, '0')));
+        return (float) key($DB->get_records_sql($sql, array($this->annotatorid, $isquestion, '0')));
     }
 
     /**
@@ -102,7 +102,7 @@ class pdfannotator_statistics {
                 . "WHERE a.course = ? AND a.id = c.pdfannotatorid AND c.isquestion = ? AND c.isdeleted = ?"
                 . "GROUP BY c.userid ) AS counts";
 
-        return key($DB->get_records_sql($sql, array($this->courseid, $isquestion, '0')));
+        return (float) key($DB->get_records_sql($sql, array($this->courseid, $isquestion, '0')));
     }
 
     /**


### PR DESCRIPTION
Running Moodle on PHP 8 and clicking on statistics tab, following error occurs:

![image](https://user-images.githubusercontent.com/40361859/176376965-6b7707b2-d1a8-46c8-9155-d1d1e159eebd.png)

The round() function does not like strings since PHP 8. So we have to convert average values to float.