### PR TITLE
CI Integration re-enabled.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -29,6 +29,18 @@ jobs:
       matrix:
         include:
           - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_400_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_400_STABLE
+            database: mariadb
+          - php: 7.4
             moodle-branch: MOODLE_311_STABLE
             database: pgsql
           - php: 7.4
@@ -44,7 +56,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 


### PR DESCRIPTION
Your CI Github workflows branches do not provide any runners any more.
This brings Github workflows runs back again.
Also Moodle 4.0 and 4.1 should be tested.