### PR TITLE
Remove deprecated definitions and function for 4.5 compatibility

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -31,7 +31,7 @@ $messageproviders = array (
     'newquestion' => array (
         'capability'  => 'mod/pdfannotator:recievenewquestionnotifications', // All capabilities.
         'defaults' => array(
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED,
             'email' => MESSAGE_PERMITTED,
         ),
     ),

--- a/lib.php
+++ b/lib.php
@@ -76,6 +76,7 @@ function pdfannotator_supports($feature) {
 function pdfannotator_get_extra_capabilities() {
     return array('moodle/site:accessallgroups');
 }
+
 /**
  * This function is used by the reset_course_userdata function in moodlelib.
  * @param $data the data submitted from the reset course.


### PR DESCRIPTION
when installing the plugin on my 4.5dev (Build: 20240726) then i can't install it because of a few deprecated defines and a deprecated function (which was empty anyway). I have removed these and then the install worked.