### PR TITLE
fix deleting empty before_standard_html_head for moodle 4.4 release

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -68,14 +68,7 @@ function pdfannotator_supports($feature) {
             return null;
     }
 }
-/**
- * Function currently unused.
- *
- * @return string
- */
-function mod_pdfannotator_before_standard_html_head() {
 
-}
 /**
  * Returns all other caps used in module
  * @return array

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_pdfannotator';
-$plugin->version   = 2023112900;
-$plugin->release  = 'PDF Annotator v1.5 release 5';
+$plugin->version   = 2023112901;
+$plugin->release  = 'PDF Annotator v1.5 release 6';
 $plugin->requires  = 2021051700;
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
In Moodle 4.4 the function "before_standard_html_head" became deprecated and should be used by a hook instead. Since pdfannotator has a stub for this function, a debug message is shown on every page. As there is no function behind, you can just delete it.