### PR TITLE
Remove deprecated constant in moodle 4.5

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -31,7 +31,7 @@ $messageproviders = array (
     'newquestion' => array (
         'capability'  => 'mod/pdfannotator:recievenewquestionnotifications', // All capabilities.
         'defaults' => array(
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
             'email' => MESSAGE_PERMITTED,
         ),
     ),


### PR DESCRIPTION
Update messages.php
Replace deprecated MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF with MESSAGE_DEFAULT_ENABLED

See also: https://github.com/rwthmoodle/moodle-mod_pdfannotator/issues/118#issue-2582712517