### PR TITLE
#132 The deprecated function get_all_user_name fields should be replaced

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -631,7 +631,11 @@ function pdfannotator_get_recent_mod_activity(&$activities, &$index, $timestart,
     } else {
         $groupselect = "";
     }
-    $allnames = get_all_user_name_fields(true, 'u');
+    if (class_exists('\core_user\fields')) {
+        $allnames = \core_user\fields::for_name()->get_sql('u', false, '','',false)->selects;
+    } else {
+        $allnames = get_all_user_name_fields(true, 'u');
+    }
     if (!$posts = $DB->get_records_sql("SELECT p.*,c.id, c.userid AS userid, c.visibility, c.content, c.timecreated, c.annotationid, c.isquestion,
                                               $allnames, u.email, u.picture, u.imagealt, u.email, a.page
                                          FROM {pdfannotator} p


### PR DESCRIPTION
The ``\core_user\fields`` API should be applied if possible.